### PR TITLE
Upgrade otel4s-core-trace to 0.12.0-RC3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val core = project
       // https://mvnrepository.com/artifact/org.typelevel/cats-effect
       "org.typelevel" %%% "cats-effect" % "3.5.7",
       // https://mvnrepository.com/artifact/org.typelevel/otel4s-core-trace
-      "org.typelevel" %%% "otel4s-core-trace" % "0.12.0-RC2",
+      "org.typelevel" %%% "otel4s-core-trace" % "0.12.0-RC3",
       // https://mvnrepository.com/artifact/org.tpolecat/doobie-core
       "org.tpolecat" %%% "doobie-core" % "1.0.0-RC8",
       // https://mvnrepository.com/artifact/org.scalameta/munit

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,15 @@ override def ivyDeps = Agg(
 You can see all the published artifacts on 
 [MVN Repository](https://mvnrepository.com/artifact/io.github.arturaz/otel4s-doobie).
 
+#### Versions table
+
+Due to the usage of RC versions, binary compatibility is finicky. Consult this table to know which versions are compatible.
+
+| Library Version | Doobie Version | Otel4s Version |
+| --------------- | -------------- | -------------- |
+| 0.3.0           | 1.0.0-RC8      | 0.12.0-RC3     |
+| 0.2.0           | 1.0.0-RC8      | 0.12.0-RC2     |
+
 ### Usage
 
 ```scala mdoc


### PR DESCRIPTION
Hello! I'm very interested in this project. I have a project I'm trying to switch over to otel4s and Tapir, and found this project which appears to do exactly what I wanted it to.

I was having issues with the transitive dependencies and noticed there's a new version of otel4s-core-trace, so thought I'd open a PR here to upgrade. I tested this change locally and it appears to work.